### PR TITLE
Fixed merge issue and crash when a build is running

### DIFF
--- a/src/components/build/build.tsx
+++ b/src/components/build/build.tsx
@@ -21,7 +21,7 @@ export default class Build extends React.Component<IBuildProps, any> {
           {this.showProgressBar()}
           <div className="info-bar">
             <CardSubtitle className="subtitle">
-              #{this.props.buildNumber} - {this.props.time.toLocaleString()}
+              #{this.props.buildNumber} - {this.props.time ? this.props.time.toLocaleString() : 'Unknown'}
             </CardSubtitle>
           </div>
         </Card>

--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -36,7 +36,6 @@ export default class BuildService {
         User: build[0].requestedFor.displayName
       });
     }
-    return builds;
     return builds.sort((a, b) => (a.Name <= b.Name ? -1 : 1));
   }
 


### PR DESCRIPTION
When a build is running in VSTS, the build has no end time so therefore it needs to take into account that the end time is unknown.

"Unknown" is a placeholder which will be replaced when we are tracking builds that are running.