### PR TITLE
Render builds that are in progress correctly

### DIFF
--- a/src/components/build/build.tsx
+++ b/src/components/build/build.tsx
@@ -1,20 +1,43 @@
 import * as moment from 'moment';
 import * as React from 'react';
 import { Card, CardSubtitle, CardTitle, Progress } from 'reactstrap';
+import { BuildResult, BuildStatus } from 'vso-node-api/interfaces/BuildInterfaces';
 import './build.css';
 
 export interface IBuildProps {
   buildName: string;
   buildNumber: string;
-  status: boolean;
+  result: number;
+  status: number;
   time: Date;
 }
 
+/**
+ * This is responsible for rendering a build
+ */
 export default class Build extends React.Component<IBuildProps, any> {
-  private progressValue: number = 0;
-  private buildStatus: string = this.props.status ? 'success' : 'danger';
+  /**
+   * Ultimately will represent what colour to render the build
+   */
+  private buildStatus: string;
 
+  /**
+   * How far has the build progressed whilst running
+   */
+  private progressValue: number = 0;
+
+  /**
+   * Render the component
+   */
   public render() {
+    if (this.props.result === BuildResult.Succeeded) {
+      this.buildStatus = 'success';
+    } else if (this.props.status === BuildStatus.InProgress) {
+      this.buildStatus = 'warning';
+    } else {
+      this.buildStatus = 'danger';
+    }
+
     return (
       <div className="card-holder">
         <Card className="shadow" body={true} inverse={true} color={this.buildStatus}>

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -19,7 +19,7 @@ export default class Main extends React.Component<IMainProps, IMainState> {
     const numCols = this.props.NumberOfColumns;
     const builds =
       this.state && this.state.Builds
-        ? this.state.Builds.map(b => <Build key={b.Name + b.BuildNumber} buildName={b.Name} buildNumber={b.BuildNumber} status={b.Status} time={b.EndTime} />)
+        ? this.state.Builds.map(b => <Build key={b.name + b.buildNumber} buildName={b.name} buildNumber={b.buildNumber} result={b.result} status={b.status} time={b.endTime} />)
         : [];
 
     const cols = [];

--- a/src/services/build-data.ts
+++ b/src/services/build-data.ts
@@ -1,8 +1,40 @@
+/**
+ * Represents the build data from VSTS
+ */
 export default class BuildData {
-  public Name: string;
-  public Status: boolean;
-  public User: string;
-  public BuildNumber: string;
-  public StartTime: Date;
-  public EndTime: Date;
+
+  /**
+   * The build number
+   */
+  public buildNumber: string;
+
+  /**
+   * The time the build finished
+   */
+  public endTime: Date;
+
+  /**
+   * The name of the build
+   */
+  public name: string;
+
+  /**
+   * The result of the build
+   */
+  public result: number;
+
+  /**
+   * The time the build was kicked off
+   */
+  public startTime: Date;
+
+  /**
+   * The status of the build
+   */
+  public status: number;
+
+  /**
+   * The user who kicked the build off
+   */
+  public user: string;
 }

--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -28,15 +28,16 @@ export default class BuildService {
         1
       );
       builds.push({
-        BuildNumber: build[0].buildNumber,
-        EndTime: build[0].finishTime,
-        Name: build[0].definition.name,
-        StartTime: build[0].startTime,
-        Status: build[0].result === 2,
-        User: build[0].requestedFor.displayName
+        buildNumber: build[0].buildNumber,
+        endTime: build[0].finishTime,
+        name: build[0].definition.name,
+        result: build[0].result,
+        startTime: build[0].startTime,
+        status: build[0].status,
+        user: build[0].requestedFor.displayName
       });
     }
-    return builds.sort((a, b) => (a.Name.toUpperCase() <= b.Name.toUpperCase() ? -1 : 1));
+    return builds.sort((a, b) => (a.name.toUpperCase() <= b.name.toUpperCase() ? -1 : 1));
   }
 
   private async getApi(): Promise<vm.WebApi> {


### PR DESCRIPTION
We need to take into consideration the build status and the build result in order to render builds that are in progress correctly.

This is a bit of `tslint:al` changes in here too as it would be nice to be as strict as possible